### PR TITLE
Testing OwnedStorage trait, growable AllocVec

### DIFF
--- a/benches/maps.rs
+++ b/benches/maps.rs
@@ -55,7 +55,7 @@ macro_rules! removals {
         #[bench]
         fn $fnn(b: &mut Bencher) {
             let mut rng = SmallRng::seed_from_u64(0x5432_1012_3454_3210);
-            let mut pairs = coca::AllocVec::<(u32, u32), usize>::with_capacity($n);
+            let mut pairs = coca::collections::AllocVec::<(u32, u32), usize>::with_capacity($n);
             for _ in 0..$n {
                 pairs.push((rng.next_u32(), rng.next_u32()));
             }
@@ -77,7 +77,7 @@ macro_rules! removals {
 
 mod unordered {
     use super::*;
-    use coca::AllocVec;
+    use coca::collections::AllocVec;
     use std::collections::HashMap as StdHashMap;
 
     #[allow(unconditional_recursion)] // false positive!
@@ -167,7 +167,7 @@ mod unordered {
 
 mod ordered {
     use super::*;
-    use coca::AllocVec;
+    use coca::collections::AllocVec;
     use std::collections::BTreeMap;
 
     impl<K, V> Map<K, V> for BTreeMap<K, V>

--- a/src/collections/list_map.rs
+++ b/src/collections/list_map.rs
@@ -14,6 +14,8 @@ use self::Entry::{Occupied, Vacant};
 /// The [`LayoutSpec`] for a [`ListMap`].
 pub struct ListMapLayout<K, V>(PhantomData<(K, V)>);
 impl<K, V> LayoutSpec for ListMapLayout<K, V> {
+    type Item = (K, V);
+
     fn layout_with_capacity(items: usize) -> Result<Layout, LayoutError> {
         let keys_array = Layout::array::<K>(items)?;
         let values_array = Layout::array::<V>(items)?;

--- a/src/collections/list_map.rs
+++ b/src/collections/list_map.rs
@@ -849,6 +849,8 @@ pub struct InlineStorage<K, V, const N: usize> {
 }
 
 unsafe impl<K, V, const N: usize> Storage<ListMapLayout<K, V>> for InlineStorage<K, V, N> {
+    const MIN_REPRESENTABLE: usize = N;
+
     fn get_ptr(&self) -> *const u8 {
         (self as *const Self).cast()
     }

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -596,6 +596,11 @@ pub type ArenaVec<'a, T, I = usize> = Vec<T, ArenaStorage<'a, ArrayLayout<T>>, I
 /// ```
 pub type AllocVec<T, I = usize> = Vec<T, crate::storage::AllocStorage<ArrayLayout<T>>, I>;
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "alloc")))]
+/// A heap-allocated vector which automatically reallocates.
+pub type ReallocVec<T, I = usize> = Vec<T, crate::storage::ReallocStorage<ArrayLayout<T>>, I>;
+
 /// A vector using an inline array for storage.
 ///
 /// # Examples

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -599,6 +599,16 @@ pub type AllocVec<T, I = usize> = Vec<T, crate::storage::AllocStorage<ArrayLayou
 #[cfg(feature = "alloc")]
 #[cfg_attr(docs_rs, doc(cfg(feature = "alloc")))]
 /// A heap-allocated vector which automatically reallocates.
+///
+/// # Examples
+/// ```
+/// let mut vec = coca::collections::ReallocVec::<char>::new();
+/// vec.push('a');
+/// vec.push('b');
+/// vec.push('c');
+/// assert_eq!(vec.len(), 3);
+/// assert_eq!(vec.capacity(), 4);
+/// ```
 pub type ReallocVec<T, I = usize> = Vec<T, crate::storage::ReallocStorage<ArrayLayout<T>>, I>;
 
 /// A vector using an inline array for storage.

--- a/src/collections/pool/direct.rs
+++ b/src/collections/pool/direct.rs
@@ -21,6 +21,8 @@ union Slot<T, I: Capacity> {
 /// The [`LayoutSpec`] for a [`DirectPool`].
 pub struct DirectPoolLayout<T, H>(PhantomData<(T, H)>);
 impl<T, H: Handle> LayoutSpec for DirectPoolLayout<T, H> {
+    type Item = (T, H::Index, u32);
+
     fn layout_with_capacity(items: usize) -> Result<Layout, LayoutError> {
         let item_array = Layout::array::<Slot<T, H::Index>>(items)?;
         let gen_count_array = Layout::array::<u32>(items)?;

--- a/src/collections/pool/direct.rs
+++ b/src/collections/pool/direct.rs
@@ -1135,6 +1135,8 @@ pub struct InlineStorage<T, H: Handle, const N: usize> {
 unsafe impl<T, H: Handle, const N: usize> Storage<DirectPoolLayout<T, H>>
     for InlineStorage<T, H, N>
 {
+    const MIN_REPRESENTABLE: usize = N;
+
     #[inline]
     fn get_ptr(&self) -> *const u8 {
         (self as *const Self).cast()

--- a/src/collections/pool/packed.rs
+++ b/src/collections/pool/packed.rs
@@ -17,6 +17,8 @@ use crate::storage::{Capacity, LayoutSpec, Storage};
 /// The [`LayoutSpec`] for a [`PackedPool`].
 pub struct PackedPoolLayout<T, H>(PhantomData<(T, H)>);
 impl<T, H: Handle> LayoutSpec for PackedPoolLayout<T, H> {
+    type Item = (T, H, u32, H::Index);
+
     fn layout_with_capacity(items: usize) -> Result<Layout, LayoutError> {
         let values_array = Layout::array::<T>(items)?;
         let handles_array = Layout::array::<H>(items)?;

--- a/src/collections/pool/packed.rs
+++ b/src/collections/pool/packed.rs
@@ -1155,6 +1155,7 @@ pub struct InlineStorage<T, H: Handle, const N: usize> {
 unsafe impl<T, H: Handle, const N: usize> Storage<PackedPoolLayout<T, H>>
     for InlineStorage<T, H, N>
 {
+    const MIN_REPRESENTABLE: usize = N;
     fn get_ptr(&self) -> *const u8 {
         (self as *const Self).cast()
     }

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1142,7 +1142,7 @@ impl<T, S: DefaultStorage<ArrayLayout<T>>, I: Capacity> Vec<T, S, I> {
     /// ```
     #[inline]
     pub fn new() -> Self {
-        if !S::supported_capacity::<I>() {
+        if S::MIN_REPRESENTABLE > I::MAX_REPRESENTABLE {
             buffer_too_large_for_index_type::<I>();
         }
         Self::UNINIT
@@ -1156,7 +1156,7 @@ impl<T, S: OwnedStorage<ArrayLayout<T>>, I: Capacity> Vec<T, S, I> {
     /// Panics if the specified capacity cannot be represented by a `usize`
     /// or if the capacity exceeds the maximum supported by the backing Storage.
     pub fn with_capacity(capacity: I) -> Self {
-        if !S::supported_capacity::<I>() {
+        if S::MIN_REPRESENTABLE > I::MAX_REPRESENTABLE {
             buffer_too_large_for_index_type::<I>();
         }
         Vec {

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1957,5 +1957,16 @@ mod tests {
 
         let v = ReallocVec::<u32>::from_iter([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         assert_eq!(v.capacity(), 10);
+
+        // test initial capacities based on size_of<T>
+        let mut v = ReallocVec::<u8>::new();
+        v.push(1u8);
+        assert_eq!(v.capacity(), 8);
+        let mut v = ReallocVec::<u32>::new();
+        v.push(1u32);
+        assert_eq!(v.capacity(), 4);
+        let mut v = ReallocVec::<[u8; 1025]>::new();
+        v.push([1u8; 1025]);
+        assert_eq!(v.capacity(), 1);
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -411,6 +411,7 @@ unsafe impl<R: LayoutSpec, S: Storage<R>> Storage<R> for &mut S {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "alloc")))]
 /// Policy for heap storage (re)allocation.
 pub unsafe trait AllocPolicy {
     #[inline]
@@ -425,14 +426,17 @@ pub unsafe trait AllocPolicy {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "alloc")))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// An allocation policy for constant capacity storage.
 pub struct NoResize;
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "alloc")))]
 unsafe impl AllocPolicy for NoResize {}
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "alloc")))]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 /// An allocation policy using exponential growth.
 pub struct ExpGrow;
@@ -449,6 +453,7 @@ const fn min_non_zero_cap<T>() -> usize {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "alloc")))]
 unsafe impl AllocPolicy for ExpGrow {
     #[inline]
     fn try_grow<R: LayoutSpec, I: Capacity>(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -455,9 +455,9 @@ unsafe impl AllocPolicy for ExpGrow {
         from_capacity: usize,
         min_capacity: Option<usize>,
     ) -> Result<(NonNull<u8>, usize), CapacityError> {
-        let min_cap = min_capacity.unwrap_or(min_non_zero_cap::<R::Item>());
+        let min_cap = min_capacity.unwrap_or(0).max(min_non_zero_cap::<R::Item>());
         let cap = min_cap.max((from_capacity.saturating_mul(2)).min(I::MAX_REPRESENTABLE));
-        if cap == from_capacity || cap < min_cap {
+        if cap <= from_capacity || cap < min_cap {
             return CapacityError::new();
         }
 


### PR DESCRIPTION
For my needs it's pretty important to support a heap Vec that can reallocate, as well as being able to support either inline or allocated Vecs depending on what features are enabled. I put together this set of changes to test a few updates. I see you've created an issue recently which suggests adding a new GrowableVec type; that could also be supported under this general scheme, leaving AllocVec as constant capacity.

Here, the `OwnedStorage` trait allows for `new`, `with_capacity`, `Clone`, `Default`, and `From` to be supported for multiple storage types, including custom storage types that might be implemented externally. An interesting example would be a zeroizing buffer, which would have better characteristics than a `Zeroizing<Vec<T>>` (from the zeroize crate) because that type is not able to account for copies made during reallocations.

In order to support `new` for `AllocVec` it needs to either define a minimum capacity or behave like the standard Vec and start with no allocation, I chose the second option here. The realloc code would probably need significant work in order to optimize it and handle corner cases.